### PR TITLE
Add dependency on termcolor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyyaml
 ruamel.yaml
 robosuite
 h5py
+termcolor


### PR DESCRIPTION
```
    from termcolor import colored
ModuleNotFoundError: No module named 'termcolor'
```